### PR TITLE
Allow collections to be ordered by publish date

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,8 +30,6 @@ func Setup(ctx context.Context, r *mux.Router, paginator Paginator, collectionSt
 // WriteJSONBody marshals the provided interface into json, and writes it to the response body.
 func WriteJSONBody(ctx context.Context, v interface{}, w http.ResponseWriter, data log.Data) error {
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-
 	body, err := json.Marshal(v)
 	if err != nil {
 		handleError(ctx, err, w, data)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/ONSdigital/dp-collection-api/api"
 	"github.com/ONSdigital/dp-collection-api/api/mock"
+	"github.com/ONSdigital/dp-collection-api/collections"
 	"github.com/ONSdigital/dp-collection-api/models"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	collectionStore := &mock.CollectionStoreMock{
-		GetCollectionsFunc: func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+		GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 			return []models.Collection{}, 0, nil
 		},
 	}

--- a/api/collection.go
+++ b/api/collection.go
@@ -15,6 +15,7 @@ var collectionsOrderBy = map[string]collections.OrderBy{
 	"publish_date": collections.OrderByPublishDate,
 }
 
+// GetCollectionsHandler handles HTTP requests for the get collections endpoint
 func (api *API) GetCollectionsHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	logData := log.Data{}

--- a/api/collection.go
+++ b/api/collection.go
@@ -1,11 +1,19 @@
 package api
 
 import (
+	"github.com/ONSdigital/dp-collection-api/collections"
 	"github.com/ONSdigital/dp-collection-api/models"
 	"github.com/ONSdigital/dp-collection-api/pagination"
 	"github.com/ONSdigital/log.go/v2/log"
 	"net/http"
+	"strings"
 )
+
+// collectionsOrderBy defines the supported order by values for ordering collection results.
+// the string represents the value as it is in the request query string.
+var collectionsOrderBy = map[string]collections.OrderBy{
+	"publish_date": collections.OrderByPublishDate,
+}
 
 func (api *API) GetCollectionsHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -19,7 +27,14 @@ func (api *API) GetCollectionsHandler(w http.ResponseWriter, req *http.Request) 
 	logData["offset"] = offset
 	logData["limit"] = limit
 
-	collections, totalCount, err := api.collectionStore.GetCollections(ctx, offset, limit)
+	orderBy, err := parseCollectionsOrderBy(req)
+	if err != nil {
+		handleError(ctx, err, w, logData)
+		return
+	}
+	logData["order_by"] = orderBy
+
+	collections, totalCount, err := api.collectionStore.GetCollections(ctx, offset, limit, orderBy)
 	if err != nil {
 		handleError(ctx, err, w, logData)
 		return
@@ -35,5 +50,21 @@ func (api *API) GetCollectionsHandler(w http.ResponseWriter, req *http.Request) 
 		},
 	}
 
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	WriteJSONBody(ctx, response, w, logData)
+}
+
+func parseCollectionsOrderBy(req *http.Request) (collections.OrderBy, error) {
+
+	orderByInput := strings.ToLower(req.URL.Query().Get("order_by"))
+	if len(orderByInput) > 0 {
+		orderBy, ok := collectionsOrderBy[orderByInput]
+		if !ok {
+			return 0, collections.ErrInvalidOrderBy
+		}
+
+		return orderBy, nil
+	}
+
+	return collections.OrderByDefault, nil
 }

--- a/api/collection_test.go
+++ b/api/collection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/ONSdigital/dp-collection-api/api/mock"
+	"github.com/ONSdigital/dp-collection-api/collections"
 	"github.com/ONSdigital/dp-collection-api/models"
 	"github.com/ONSdigital/dp-collection-api/pagination"
 	"github.com/gorilla/mux"
@@ -34,7 +35,7 @@ func TestGetCollections(t *testing.T) {
 		}
 
 		collectionStore := &mock.CollectionStoreMock{
-			GetCollectionsFunc: func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+			GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 				return []models.Collection{{
 					ID:          "123",
 					Name:        "collection 1",
@@ -59,8 +60,10 @@ func TestGetCollections(t *testing.T) {
 
 			Convey("Then the collection store is called to get collection data", func() {
 				So(len(collectionStore.GetCollectionsCalls()), ShouldEqual, 1)
-				So(collectionStore.GetCollectionsCalls()[0].Limit, ShouldEqual, limit)
-				So(collectionStore.GetCollectionsCalls()[0].Offset, ShouldEqual, offset)
+				getCollectionsCall := collectionStore.GetCollectionsCalls()[0]
+				So(getCollectionsCall.Limit, ShouldEqual, limit)
+				So(getCollectionsCall.Offset, ShouldEqual, offset)
+				So(getCollectionsCall.OrderBy, ShouldEqual, collections.OrderByDefault)
 			})
 
 			Convey("Then the response has the expected status code", func() {
@@ -78,6 +81,55 @@ func TestGetCollections(t *testing.T) {
 				So(response.Offset, ShouldEqual, offset)
 				So(response.Limit, ShouldEqual, limit)
 				So(response.TotalCount, ShouldEqual, totalCount)
+			})
+		})
+	})
+}
+
+func TestGetCollections_orderBy(t *testing.T) {
+
+	offset := 0
+	limit := 1
+	totalCount := 3
+
+	Convey("Given a request to GET collections", t, func() {
+
+		paginator := &mock.PaginatorMock{
+			ReadPaginationParametersFunc: func(r *http.Request) (int, int, error) {
+				return offset, limit, nil
+			},
+		}
+
+		collectionStore := &mock.CollectionStoreMock{
+			GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
+				return []models.Collection{{
+					ID:          "123",
+					Name:        "collection 1",
+					PublishDate: time.Time{},
+					LastUpdated: time.Time{},
+				}}, totalCount, nil
+			},
+		}
+
+		r := httptest.NewRequest("GET", "http://localhost:26000/collections?order_by=publish_date", nil)
+		w := httptest.NewRecorder()
+
+		Convey("When the request is sent to the API", func() {
+
+			api := api.Setup(context.Background(), mux.NewRouter(), paginator, collectionStore)
+			api.GetCollectionsHandler(w, r)
+
+			Convey("Then the paginator is called to extract pagination parameters", func() {
+				So(len(paginator.ReadPaginationParametersCalls()), ShouldEqual, 1)
+				So(paginator.ReadPaginationParametersCalls()[0].R, ShouldEqual, r)
+			})
+
+			Convey("Then the collection store is called with the expected orderBy value", func() {
+				So(len(collectionStore.GetCollectionsCalls()), ShouldEqual, 1)
+				getCollectionsCall := collectionStore.GetCollectionsCalls()[0]
+				So(getCollectionsCall.Limit, ShouldEqual, limit)
+				So(getCollectionsCall.Offset, ShouldEqual, offset)
+				So(getCollectionsCall.OrderBy, ShouldEqual, collections.OrderByPublishDate)
 			})
 		})
 	})
@@ -126,7 +178,7 @@ func TestGetCollections_collectionStoreError(t *testing.T) {
 		}
 
 		collectionStore := &mock.CollectionStoreMock{
-			GetCollectionsFunc: func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+			GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 				return nil, 0, errors.New("store error")
 			},
 		}
@@ -146,6 +198,52 @@ func TestGetCollections_collectionStoreError(t *testing.T) {
 
 			Convey("Then the expected error code is returned", func() {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+	})
+}
+
+func TestGetCollections_invalidOrderByError(t *testing.T) {
+
+	Convey("Given an invalid orderBy value", t, func() {
+
+		paginator := &mock.PaginatorMock{
+			ReadPaginationParametersFunc: func(r *http.Request) (int, int, error) {
+				return 0, 0, nil
+			},
+		}
+
+		collectionStore := &mock.CollectionStoreMock{
+			GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
+				return nil, 0, errors.New("store error")
+			},
+		}
+
+		Convey("When the request is made to GET collections", func() {
+
+			r := httptest.NewRequest("GET", "http://localhost:26000/collections?order_by=fubar", nil)
+			w := httptest.NewRecorder()
+
+			api := api.Setup(context.Background(), mux.NewRouter(), paginator, collectionStore)
+			api.GetCollectionsHandler(w, r)
+
+			Convey("Then the paginator is called to extract pagination parameters", func() {
+				So(len(paginator.ReadPaginationParametersCalls()), ShouldEqual, 1)
+				So(paginator.ReadPaginationParametersCalls()[0].R, ShouldEqual, r)
+			})
+
+			Convey("Then the expected error code is returned", func() {
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+
+			Convey("Then the response body should contain the expected error response", func() {
+				body, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				response := models.ErrorsResponse{}
+				err = json.Unmarshal(body, &response)
+				So(err, ShouldBeNil)
+				So(len(response.Errors), ShouldEqual, 1)
+				So(response.Errors[0].Message, ShouldEqual, collections.ErrInvalidOrderBy.Error())
 			})
 		})
 	})

--- a/api/collection_test.go
+++ b/api/collection_test.go
@@ -86,7 +86,7 @@ func TestGetCollections(t *testing.T) {
 	})
 }
 
-func TestGetCollections_orderBy(t *testing.T) {
+func TestGetCollections_orderByPublishDate(t *testing.T) {
 
 	offset := 0
 	limit := 1
@@ -119,17 +119,54 @@ func TestGetCollections_orderBy(t *testing.T) {
 			api := api.Setup(context.Background(), mux.NewRouter(), paginator, collectionStore)
 			api.GetCollectionsHandler(w, r)
 
-			Convey("Then the paginator is called to extract pagination parameters", func() {
-				So(len(paginator.ReadPaginationParametersCalls()), ShouldEqual, 1)
-				So(paginator.ReadPaginationParametersCalls()[0].R, ShouldEqual, r)
-			})
-
 			Convey("Then the collection store is called with the expected orderBy value", func() {
 				So(len(collectionStore.GetCollectionsCalls()), ShouldEqual, 1)
 				getCollectionsCall := collectionStore.GetCollectionsCalls()[0]
 				So(getCollectionsCall.Limit, ShouldEqual, limit)
 				So(getCollectionsCall.Offset, ShouldEqual, offset)
 				So(getCollectionsCall.OrderBy, ShouldEqual, collections.OrderByPublishDate)
+			})
+		})
+	})
+}
+
+func TestGetCollections_emptyOrderBy(t *testing.T) {
+
+	offset := 0
+	limit := 1
+	totalCount := 3
+
+	Convey("Given a request to GET collections with an empty order_by value", t, func() {
+
+		paginator := &mock.PaginatorMock{
+			ReadPaginationParametersFunc: func(r *http.Request) (int, int, error) {
+				return offset, limit, nil
+			},
+		}
+
+		collectionStore := &mock.CollectionStoreMock{
+			GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
+				return []models.Collection{{
+					ID:          "123",
+					Name:        "collection 1",
+					PublishDate: time.Time{},
+					LastUpdated: time.Time{},
+				}}, totalCount, nil
+			},
+		}
+
+		r := httptest.NewRequest("GET", "http://localhost:26000/collections?order_by=", nil)
+		w := httptest.NewRecorder()
+
+		Convey("When the request is sent to the API", func() {
+
+			api := api.Setup(context.Background(), mux.NewRouter(), paginator, collectionStore)
+			api.GetCollectionsHandler(w, r)
+
+			Convey("Then the collection store is called with the expected orderBy value", func() {
+				So(len(collectionStore.GetCollectionsCalls()), ShouldEqual, 1)
+				getCollectionsCall := collectionStore.GetCollectionsCalls()[0]
+				So(getCollectionsCall.OrderBy, ShouldEqual, collections.OrderByDefault)
 			})
 		})
 	})

--- a/api/errors.go
+++ b/api/errors.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-
 	// errors that should return a 400 status
 	badRequest = map[error]bool{
 		pagination.ErrInvalidLimitParameter:  true,

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-collection-api/collections"
 	"github.com/ONSdigital/dp-collection-api/models"
 	"net/http"
 )
@@ -16,5 +17,5 @@ type Paginator interface {
 
 // CollectionStore defines the required methods from the data store of collections
 type CollectionStore interface {
-	GetCollections(ctx context.Context, offset, limit int) (collections []models.Collection, totalCount int, err error)
+	GetCollections(ctx context.Context, offset, limit int, orderBy collections.OrderBy) (collections []models.Collection, totalCount int, err error)
 }

--- a/api/mock/collectionstore.go
+++ b/api/mock/collectionstore.go
@@ -6,6 +6,7 @@ package mock
 import (
 	"context"
 	"github.com/ONSdigital/dp-collection-api/api"
+	"github.com/ONSdigital/dp-collection-api/collections"
 	"github.com/ONSdigital/dp-collection-api/models"
 	"sync"
 )
@@ -20,7 +21,7 @@ var _ api.CollectionStore = &CollectionStoreMock{}
 //
 //         // make and configure a mocked api.CollectionStore
 //         mockedCollectionStore := &CollectionStoreMock{
-//             GetCollectionsFunc: func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+//             GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 // 	               panic("mock out the GetCollections method")
 //             },
 //         }
@@ -31,7 +32,7 @@ var _ api.CollectionStore = &CollectionStoreMock{}
 //     }
 type CollectionStoreMock struct {
 	// GetCollectionsFunc mocks the GetCollections method.
-	GetCollectionsFunc func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error)
+	GetCollectionsFunc func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -43,43 +44,49 @@ type CollectionStoreMock struct {
 			Offset int
 			// Limit is the limit argument value.
 			Limit int
+			// OrderBy is the orderBy argument value.
+			OrderBy collections.OrderBy
 		}
 	}
 	lockGetCollections sync.RWMutex
 }
 
 // GetCollections calls GetCollectionsFunc.
-func (mock *CollectionStoreMock) GetCollections(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+func (mock *CollectionStoreMock) GetCollections(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 	if mock.GetCollectionsFunc == nil {
 		panic("CollectionStoreMock.GetCollectionsFunc: method is nil but CollectionStore.GetCollections was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		Offset int
-		Limit  int
+		Ctx     context.Context
+		Offset  int
+		Limit   int
+		OrderBy collections.OrderBy
 	}{
-		Ctx:    ctx,
-		Offset: offset,
-		Limit:  limit,
+		Ctx:     ctx,
+		Offset:  offset,
+		Limit:   limit,
+		OrderBy: orderBy,
 	}
 	mock.lockGetCollections.Lock()
 	mock.calls.GetCollections = append(mock.calls.GetCollections, callInfo)
 	mock.lockGetCollections.Unlock()
-	return mock.GetCollectionsFunc(ctx, offset, limit)
+	return mock.GetCollectionsFunc(ctx, offset, limit, orderBy)
 }
 
 // GetCollectionsCalls gets all the calls that were made to GetCollections.
 // Check the length with:
 //     len(mockedCollectionStore.GetCollectionsCalls())
 func (mock *CollectionStoreMock) GetCollectionsCalls() []struct {
-	Ctx    context.Context
-	Offset int
-	Limit  int
+	Ctx     context.Context
+	Offset  int
+	Limit   int
+	OrderBy collections.OrderBy
 } {
 	var calls []struct {
-		Ctx    context.Context
-		Offset int
-		Limit  int
+		Ctx     context.Context
+		Offset  int
+		Limit   int
+		OrderBy collections.OrderBy
 	}
 	mock.lockGetCollections.RLock()
 	calls = mock.calls.GetCollections

--- a/collections/ordering.go
+++ b/collections/ordering.go
@@ -2,15 +2,21 @@ package collections
 
 import "errors"
 
+// ErrInvalidOrderBy is the error used when an invalid order by value is identified
 var ErrInvalidOrderBy = errors.New("invalid order_by")
 
+// OrderBy represents the subset of values that can be used for ordering results
 type OrderBy int
 
 const (
+	// OrderByDefault is used when no specific order has been specified
 	OrderByDefault OrderBy = iota
+
+	// OrderByPublishDate is used to order results by publish date
 	OrderByPublishDate
 )
 
+// String returns a string representation of the OrderBy instance
 func (ob OrderBy) String() string {
 	return []string{"default", "publish_date"}[ob]
 }

--- a/collections/ordering.go
+++ b/collections/ordering.go
@@ -1,0 +1,16 @@
+package collections
+
+import "errors"
+
+var ErrInvalidOrderBy = errors.New("invalid order_by")
+
+type OrderBy int
+
+const (
+	OrderByDefault OrderBy = iota
+	OrderByPublishDate
+)
+
+func (ob OrderBy) String() string {
+	return []string{"default", "publish_date"}[ob]
+}

--- a/features/get_collections.feature
+++ b/features/get_collections.feature
@@ -37,3 +37,53 @@ Feature: Get Collections
                 ]
             }
             """
+
+    Scenario: GET /collections with order
+        Given I have these collections:
+            """
+            [
+                {
+                    "id": "abc123",
+                    "name": "LMSV1",
+                    "publish_date": "2020-05-10T14:58:29.317Z"
+                },
+                {
+                    "id": "abc124",
+                    "name": "LMSV2",
+                    "publish_date": "2020-05-05T14:58:29.317Z"
+                },
+                {
+                    "id": "abc125",
+                    "name": "LMSV3",
+                    "publish_date": "2020-05-08T14:58:29.317Z"
+                }
+            ]
+            """
+        When I GET "/collections?order_by=publish_date"
+        Then the HTTP status code should be "200"
+        And the response header "Content-Type" should be "application/json; charset=utf-8"
+        And I should receive the following JSON response:
+            """
+            {
+                "count": 3,
+                "limit": 20,
+                "offset": 0,
+                "total_count": 3,
+                "items": [
+                    { "id": "abc124", "name": "LMSV2", "publish_date": "2020-05-05T14:58:29.317Z" },
+                    { "id": "abc125", "name": "LMSV3", "publish_date": "2020-05-08T14:58:29.317Z" },
+                    { "id": "abc123", "name": "LMSV1", "publish_date": "2020-05-10T14:58:29.317Z" }
+                ]
+            }
+            """
+
+    Scenario: GET /collections with invalid order
+        When I GET "/collections?order_by=FUBAR"
+        Then the HTTP status code should be "400"
+        And the response header "Content-Type" should be "application/json; charset=utf-8"
+        And I should receive the following JSON response:
+            """
+            {
+                "errors":[ {"message":  "invalid order_by"}]
+            }
+            """

--- a/models/error.go
+++ b/models/error.go
@@ -1,0 +1,11 @@
+package models
+
+// ErrorsResponse represents a slice of errors in a JSON response body
+type ErrorsResponse struct {
+	Errors []ErrorResponse `json:"errors"`
+}
+
+// ErrorResponse represents a single error in a JSON response body
+type ErrorResponse struct {
+	Message string `json:"message"`
+}

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -7,17 +7,24 @@ import (
 )
 
 var (
+	// ErrInvalidOffsetParameter represents an error case where an invalid offset value is provided
 	ErrInvalidOffsetParameter = errors.New("invalid offset query parameter")
-	ErrInvalidLimitParameter  = errors.New("invalid limit query parameter")
-	ErrLimitOverMax           = errors.New("limit query parameter is larger than the maximum allowed")
+
+	// ErrInvalidLimitParameter represents an error case where an invalid limit value is provided
+	ErrInvalidLimitParameter = errors.New("invalid limit query parameter")
+
+	// ErrLimitOverMax represents an error case where the given limit value is larger than the maximum allowed
+	ErrLimitOverMax = errors.New("limit query parameter is larger than the maximum allowed")
 )
 
+// Paginator is a type to hold pagination related defaults, and provides helper functions using the defaults if needed
 type Paginator struct {
 	DefaultLimit    int
 	DefaultOffset   int
 	DefaultMaxLimit int
 }
 
+// PaginatedResponse represents the pagination related values that go into list based response
 type PaginatedResponse struct {
 	Count      int `json:"count"`
 	Offset     int `json:"offset"`
@@ -25,6 +32,7 @@ type PaginatedResponse struct {
 	TotalCount int `json:"total_count"`
 }
 
+// NewPaginator creates a new instance
 func NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit int) *Paginator {
 	return &Paginator{
 		DefaultLimit:    defaultLimit,
@@ -33,6 +41,7 @@ func NewPaginator(defaultLimit, defaultOffset, defaultMaxLimit int) *Paginator {
 	}
 }
 
+// ReadPaginationParameters returns pagination related values based on the given request
 func (p *Paginator) ReadPaginationParameters(r *http.Request) (offset int, limit int, err error) {
 
 	offsetParameter := r.URL.Query().Get("offset")

--- a/service/mock/healthCheck.go
+++ b/service/mock/healthCheck.go
@@ -5,11 +5,10 @@ package mock
 
 import (
 	"context"
-	"net/http"
-	"sync"
-
 	"github.com/ONSdigital/dp-collection-api/service"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"net/http"
+	"sync"
 )
 
 // Ensure, that HealthCheckerMock does implement service.HealthChecker.

--- a/service/mock/mongo.go
+++ b/service/mock/mongo.go
@@ -5,6 +5,7 @@ package mock
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-collection-api/collections"
 	"github.com/ONSdigital/dp-collection-api/models"
 	"github.com/ONSdigital/dp-collection-api/service"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -27,7 +28,7 @@ var _ service.MongoDB = &MongoDBMock{}
 //             CloseFunc: func(in1 context.Context) error {
 // 	               panic("mock out the Close method")
 //             },
-//             GetCollectionsFunc: func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+//             GetCollectionsFunc: func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 // 	               panic("mock out the GetCollections method")
 //             },
 //         }
@@ -44,7 +45,7 @@ type MongoDBMock struct {
 	CloseFunc func(in1 context.Context) error
 
 	// GetCollectionsFunc mocks the GetCollections method.
-	GetCollectionsFunc func(ctx context.Context, offset int, limit int) ([]models.Collection, int, error)
+	GetCollectionsFunc func(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -68,6 +69,8 @@ type MongoDBMock struct {
 			Offset int
 			// Limit is the limit argument value.
 			Limit int
+			// OrderBy is the orderBy argument value.
+			OrderBy collections.OrderBy
 		}
 	}
 	lockChecker        sync.RWMutex
@@ -142,37 +145,41 @@ func (mock *MongoDBMock) CloseCalls() []struct {
 }
 
 // GetCollections calls GetCollectionsFunc.
-func (mock *MongoDBMock) GetCollections(ctx context.Context, offset int, limit int) ([]models.Collection, int, error) {
+func (mock *MongoDBMock) GetCollections(ctx context.Context, offset int, limit int, orderBy collections.OrderBy) ([]models.Collection, int, error) {
 	if mock.GetCollectionsFunc == nil {
 		panic("MongoDBMock.GetCollectionsFunc: method is nil but MongoDB.GetCollections was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		Offset int
-		Limit  int
+		Ctx     context.Context
+		Offset  int
+		Limit   int
+		OrderBy collections.OrderBy
 	}{
-		Ctx:    ctx,
-		Offset: offset,
-		Limit:  limit,
+		Ctx:     ctx,
+		Offset:  offset,
+		Limit:   limit,
+		OrderBy: orderBy,
 	}
 	mock.lockGetCollections.Lock()
 	mock.calls.GetCollections = append(mock.calls.GetCollections, callInfo)
 	mock.lockGetCollections.Unlock()
-	return mock.GetCollectionsFunc(ctx, offset, limit)
+	return mock.GetCollectionsFunc(ctx, offset, limit, orderBy)
 }
 
 // GetCollectionsCalls gets all the calls that were made to GetCollections.
 // Check the length with:
 //     len(mockedMongoDB.GetCollectionsCalls())
 func (mock *MongoDBMock) GetCollectionsCalls() []struct {
-	Ctx    context.Context
-	Offset int
-	Limit  int
+	Ctx     context.Context
+	Offset  int
+	Limit   int
+	OrderBy collections.OrderBy
 } {
 	var calls []struct {
-		Ctx    context.Context
-		Offset int
-		Limit  int
+		Ctx     context.Context
+		Offset  int
+		Limit   int
+		OrderBy collections.OrderBy
 	}
 	mock.lockGetCollections.RLock()
 	calls = mock.calls.GetCollections

--- a/service/mock/server.go
+++ b/service/mock/server.go
@@ -5,9 +5,8 @@ package mock
 
 import (
 	"context"
-	"sync"
-
 	"github.com/ONSdigital/dp-collection-api/service"
+	"sync"
 )
 
 // Ensure, that HTTPServerMock does implement service.HTTPServer.


### PR DESCRIPTION
### What

Add ability to sort collections by publish date.
 - `/collections` - applies default ordering, yet to be defined
 - `/collections?order_by=publish_date` - collections ordered by publish date
 - `/collections?order_by=notrecognised` - 400 response and error body

### How to review
Review changes / tests / component tests

### Who can review
Anyone
